### PR TITLE
test(ci): add pytest + coverage, tests for slideshow, local runner, a…

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+source =
+    slideshow
+omit =
+    */venv/*
+    */.venv/*
+
+[report]
+show_missing = True
+skip_covered = False
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          sudo apt-get update
+          sudo apt-get install -y python3-tk
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Run tests with coverage
+        run: pytest
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.xml
+            .coverage
+            .pytest_cache
+            htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ dist/
 # OS files
 .DS_Store
 Thumbs.db
+
+# Test/coverage artifacts
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+minversion = 8.0
+addopts = -ra -q --cov=slideshow --cov-report=term-missing --cov-report=xml
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.3.2
+pytest-cov>=5.0.0

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -1,0 +1,20 @@
+param(
+    [switch]$NoInstall
+)
+
+Write-Host "Running tests with coverage..." -ForegroundColor Cyan
+
+if (-not $NoInstall) {
+    if (Test-Path "requirements.txt") {
+        pip install -r requirements.txt
+    }
+    if (Test-Path "requirements-dev.txt") {
+        pip install -r requirements-dev.txt
+    }
+}
+
+pytest
+
+if (Test-Path "coverage.xml") {
+    Write-Host "Coverage report generated at coverage.xml" -ForegroundColor Green
+}

--- a/slideshow.py
+++ b/slideshow.py
@@ -148,6 +148,17 @@ class TATSlideshowApp:
         # Storage for answers
         self.answers = {}
         
+    def hide_current_image(self):
+        """Hide the image during writing/display phase."""
+        # Clear any image reference and show a neutral message/background
+        try:
+            self.image_label.config(image="", text="Writing phase in progress\nImage hidden", fg='#7f8c8d')
+            # Remove reference to prevent Tk keeping the old image
+            if hasattr(self.image_label, "image"):
+                self.image_label.image = None
+        except Exception:
+            pass
+
     def load_images(self):
         """Load images from the images folder"""
         image_folder = "images"
@@ -259,6 +270,8 @@ class TATSlideshowApp:
         else:  # writing phase
             self.timer_seconds = self.display_time
             self.phase_label.config(text="Writing Phase", fg='#27ae60')
+            # Ensure image is hidden whenever writing timer starts (covers resume cases)
+            self.hide_current_image()
             
         if self.timer_thread and self.timer_thread.is_alive():
             return
@@ -293,6 +306,8 @@ class TATSlideshowApp:
         if self.current_phase == "preparation":
             # Switch to writing phase
             self.current_phase = "writing"
+            # Hide image as soon as writing/display time starts
+            self.hide_current_image()
             self.start_timer()
         else:
             # Move to next image or finish

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1,0 +1,237 @@
+import builtins
+import os
+import types
+import threading
+import time
+import tkinter as tk
+from unittest import mock
+
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for `import slideshow`
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from slideshow import TATSlideshowApp
+
+
+@pytest.fixture
+def tk_root():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available in environment")
+    # Prevent the window from showing
+    root.withdraw()
+    try:
+        yield root
+    finally:
+        try:
+            root.destroy()
+        except Exception:
+            pass
+
+
+def _make_app(root):
+    app = TATSlideshowApp(root)
+    return app
+
+
+def test_initial_state_labels(tk_root):
+    app = _make_app(tk_root)
+    assert app.current_phase == "preparation"
+    assert app.is_running is False
+    assert app.is_paused is False
+    assert app.timer_seconds == 0
+    # UI labels exist
+    assert app.timer_label.cget("text") == "00:00"
+    assert "Ready" in app.phase_label.cget("text")
+
+
+def test_load_images_when_folder_missing_creates_folder(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+
+    # Avoid modal message boxes in tests
+    with mock.patch("tkinter.messagebox.showwarning") as warn:
+        from slideshow import TATSlideshowApp
+        app = TATSlideshowApp(tk_root)
+        # Newly created folder should exist
+        assert os.path.isdir("images")
+        warn.assert_called()
+
+
+def test_load_images_and_sorting(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+    # Create some numbered files out of order
+    for name in ["image_10.jpg", "image_2.jpg", "image_1.jpg"]:
+        (tmp_path / "images" / name).write_bytes(b"\x00")
+
+    with mock.patch("tkinter.messagebox.showwarning") as warn:
+        warn.side_effect = lambda *a, **k: None
+        app = _make_app(tk_root)
+
+    assert [os.path.basename(p) for p in app.images] == [
+        "image_1.jpg",
+        "image_2.jpg",
+        "image_10.jpg",
+    ]
+
+
+def test_show_current_image_updates_info(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+
+    # Create a tiny valid JPEG using PIL if available; else skip
+    try:
+        from PIL import Image
+
+        img_file = tmp_path / "images" / "image_1.jpg"
+        Image.new("RGB", (10, 10), color=(255, 0, 0)).save(img_file)
+    except Exception:
+        pytest.skip("Pillow not available in test environment")
+
+    with mock.patch("tkinter.messagebox.showwarning"):
+        app = _make_app(tk_root)
+
+    # Make Tk callbacks execute immediately (no mainloop in tests)
+    app.root.after = lambda delay, func=None, *a, **k: (func() if func else None)
+
+    app.current_image_index = 0
+    app.show_current_image()
+
+    assert app.current_image_info.cget("text").startswith("Current: image_1.jpg")
+    # image_label should now hold an image reference
+    assert hasattr(app.image_label, "image")
+
+
+def test_timer_transitions_hide_image_and_next(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+
+    try:
+        from PIL import Image
+
+        (tmp_path / "images" / "image_1.jpg").write_bytes(b"")
+        # create two images
+        Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_1.jpg")
+        Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_2.jpg")
+    except Exception:
+        pytest.skip("Pillow not available in test environment")
+
+    with mock.patch("tkinter.messagebox.showwarning"):
+        app = _make_app(tk_root)
+
+    # Set short times for fast tests
+    app.display_time = 1
+    app.preparation_time = 1
+
+    # Avoid real message boxes
+    with mock.patch("tkinter.messagebox.showinfo"):
+        # Make Tk callbacks execute immediately (no mainloop in tests)
+        app.root.after = lambda delay, func=None, *a, **k: (func() if func else None)
+
+        app.start_slideshow()
+        # Simulate end of preparation phase
+        app.timer_seconds = 0
+        app.timer_finished()
+        # Writing phase should start and image must be hidden
+        assert app.current_phase == "writing"
+        assert getattr(app.image_label, "image", None) is None
+        assert "Image hidden" in app.image_label.cget("text")
+
+        # Simulate end of writing phase to move to next image
+        app.timer_seconds = 0
+        app.timer_finished()
+        assert app.current_phase == "preparation"
+        assert app.current_image_index == 1
+
+        app.stop_slideshow()
+
+
+def test_pause_resume_updates_phase_label(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+    try:
+        from PIL import Image
+
+        Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_1.jpg")
+    except Exception:
+        pytest.skip("Pillow not available in test environment")
+
+    with mock.patch("tkinter.messagebox.showwarning"):
+        app = _make_app(tk_root)
+    # Ensure after callbacks are synchronous here as well
+    app.root.after = lambda delay, func=None, *a, **k: (func() if func else None)
+
+    app.display_time = 2
+    app.preparation_time = 2
+
+    app.start_slideshow()
+    # Pause
+    app.toggle_pause()
+    assert app.is_paused is True
+    assert app.phase_label.cget("text") == "PAUSED"
+    # Resume
+    app.toggle_pause()
+    assert app.is_paused is False
+
+    app.stop_slideshow()
+
+
+def test_save_and_clear_answer(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+    try:
+        from PIL import Image
+
+        Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_1.jpg")
+    except Exception:
+        pytest.skip("Pillow not available in test environment")
+
+    with mock.patch("tkinter.messagebox.showwarning"):
+        app = _make_app(tk_root)
+
+    app.current_image_index = 0
+    app.show_current_image()
+
+    with mock.patch("tkinter.messagebox.showinfo"):
+        app.answer_text.insert("1.0", "My story")
+        app.save_current_answer()
+
+    image_name = os.path.basename(app.images[0])
+    assert app.answers[image_name] == "My story"
+
+    app.clear_current_answer()
+    assert app.answer_text.get("1.0", tk.END).strip() == ""
+
+
+def test_export_answers(tmp_path, monkeypatch, tk_root):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("images", exist_ok=True)
+    try:
+        from PIL import Image
+
+        Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_1.jpg")
+    except Exception:
+        pytest.skip("Pillow not available in test environment")
+
+    with mock.patch("tkinter.messagebox.showwarning"):
+        app = _make_app(tk_root)
+
+    app.current_image_index = 0
+    app.show_current_image()
+    image_name = os.path.basename(app.images[0])
+    app.answers[image_name] = "A sample answer"
+
+    # Mock save dialog and messageboxes
+    with mock.patch("tkinter.filedialog.asksaveasfilename", return_value=str(tmp_path / "out.txt")):
+        with mock.patch("tkinter.messagebox.showinfo") as info:
+            app.export_answers()
+            info.assert_called()
+
+    content = (tmp_path / "out.txt").read_text(encoding="utf-8")
+    assert "A sample answer" in content

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -114,8 +114,6 @@ def test_timer_transitions_hide_image_and_next(tmp_path, monkeypatch, tk_root):
 
     try:
         from PIL import Image
-
-        (tmp_path / "images" / "image_1.jpg").write_bytes(b"")
         # create two images
         Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_1.jpg")
         Image.new("RGB", (10, 10)).save(tmp_path / "images" / "image_2.jpg")


### PR DESCRIPTION
This pull request introduces automated testing and coverage reporting for the `slideshow` application, as well as improvements to the application's writing phase behavior. The most significant changes are the addition of a GitHub Actions CI workflow, configuration for coverage reporting, new developer requirements, and a comprehensive test suite. Additionally, the slideshow now reliably hides images during the writing phase.

**Continuous Integration & Coverage Reporting**

* Added `.github/workflows/ci.yml` to run tests and upload coverage reports automatically on pushes and pull requests to `master` and `main` branches.
* Introduced `.coveragerc` and `pytest.ini` to configure coverage measurement and pytest behavior, ensuring coverage is tracked for the `slideshow` package and missing lines are reported. [[1]](diffhunk://#diff-834e9b406d74791ffbafaeec9cc894082cea9739bc347b6ff9f72312c92ebc79R1-R14) [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R1-R4)
* Updated `requirements-dev.txt` to include `pytest` and `pytest-cov` for local and CI test execution.
* Added `run-tests.ps1` PowerShell script for running tests with coverage locally, including optional dependency installation.

**Testing Improvements**

* Added `tests/test_slideshow.py` with extensive tests for application initialization, image loading, phase transitions, answer saving/exporting, and UI behaviors.

**Application Behavior**

* Implemented `hide_current_image` method in `slideshow.py` and ensured images are hidden during the writing phase by integrating it into phase transitions and timer logic. [[1]](diffhunk://#diff-ecac9f5f5d570d74d841fd4ac37de33ad61051d3028c84c8676578189830eaf8R151-R161) [[2]](diffhunk://#diff-ecac9f5f5d570d74d841fd4ac37de33ad61051d3028c84c8676578189830eaf8R273-R274) [[3]](diffhunk://#diff-ecac9f5f5d570d74d841fd4ac37de33ad61051d3028c84c8676578189830eaf8R309-R310)